### PR TITLE
fix:引数の見直し、ヘッダ情報修正

### DIFF
--- a/aws-security-group_rule.sh
+++ b/aws-security-group_rule.sh
@@ -1,80 +1,98 @@
 #!/bin/bash
 # Usage: 
-#   security_group_rule.sh <add|del> <in|out> <rule_list(csv)>
-#     add/del: Specify "add" to add rules or "del" to delete rules.
-#     in/out: Inboud or Outbound
-#     rule_list.csv: The path to the CSV file containing the list of rules to add or delete.
+#   aws-security_group_rule.sh <add|del> <in|out> <rule_list(csv)> [-y]
+#     add/del:        Specify "add" to add rules or "del" to delete rules.
+#     in/out:         Inboud or Outbound
+#     rule_list(csv): The path to the CSV file containing the list of rules to add or delete.
+#     -y:             Actually run with AWS CLI
 # Description:
 #  This script can add or delete rules for existing security groups using the AWS CLI.
 #  The CSV file should include the security group ID for the target security group.
-#    <group-id>,<protocol>,<from-port>,<to-port>,<CIDR/SGID>,<DESCRIPTION>
+#    <group-id>,<protocol>,<from-port>,<to-port>,<Destination|Source(CIDR/SGID)>,<DESCRIPTION>
 #
 
 LOG_DIR=$(cd $(dirname ${0}); pwd)/log
-LOGFILE=${LOG_DIR}/aws-sg_rule_`date '+%Y%m%d-%H%M%S'`.log
+LOGFILE=${LOG_DIR}/$(basename $0)_$(date '+%Y%m%d').log
 
 AWSCLI_CMD='aws ec2'
-USAGE="$0 <add|del|addshow|delshow> <in|out> <listfile(csv)>"
+USAGE="$0 <add|del> <in|out> <listfile(csv)> [-y]"
 
+# Argument
 ACTION=$1
 DIRECTION=$2
 RULE_LIST=$3
+EX_OPTIN=$4
 
 # Argument Count Check
-if [ $# -ne 3 ]; then
+if [ $# -ne 3 -a $# -ne 4 ]; then
     echo -e "Error: Invalid number of arguments"
     echo -e "Usage: ${USAGE}"
     exit 1
 fi
 
 # Existence of list file check
-if [ ! -f "$RULE_LIST" ]; then
-    echo "$3 does not exist."
+if [ ! -f "${RULE_LIST}" ]; then
+    echo "${RULE_LIST} does not exist."
     exit 1
 fi
 
 # Set subcommand for inbaund/outband rule 
 case "${DIRECTION}" in
-    in)
-        SUBCOM_TMP="ingress" ;;
-    out)
-        SUBCOM_TMP="egress" ;;
-    *)
+    in )
+        SUBCOM_TMP="ingress"
+        ;;
+    out )
+        SUBCOM_TMP="egress"
+        ;;
+    * )
         echo -e "Error: Invalid argument: ${DIRECTION}"
         echo -e "Usage: ${USAGE}"
-        exit 1 ;;
+        exit 2
+        ;;
 esac
 
 # Set subcommand for delet/add rule
 case ${ACTION} in
-    add|addshow ) SUBCMD="authorize-security-group-${SUBCOM_TMP}" ;;
-    del|delshow ) SUBCMD="revoke-security-group-${SUBCOM_TMP}" ;;
-    *)
-      echo -e "Error: Invalid argument: ${ACTION}"
-      echo -e "Usage: ${USAGE}"
-      exit 10
-      ;;
+    add )
+        SUBCMD="authorize-security-group-${SUBCOM_TMP}"
+        ;;
+    del )
+        SUBCMD="revoke-security-group-${SUBCOM_TMP}"
+        ;;
+    * )
+        echo -e "Error: Invalid argument: ${ACTION}"
+        echo -e "Usage: ${USAGE}"
+        exit 2
+        ;;
 esac
 
 # Check logfile directory and make
 test ! -d ${LOG_DIR} && mkdir ${LOG_DIR}
+echo -e "" >> ${LOGFILE}
+echo -e "# Running scripts. $(uname -n)@$(whoami) Time: $(date '+%Y-%m-%d %H:%M:%S')" | tee -a ${LOGFILE}
 
 # function: AWS-CLI commnd create
 function func_create_cmd() {
-    SECURITY_GROUP_ID=$1
+    SG_ID=$1
     PROTOCOL=$2
     FROM_PORT=$3
     TO_PORT=$4
-    CIDER_SGID=$5
+    DEST_SRC=$5
     DESCRIPTION=$6
     
     # Set subcommand parameter: Source/destination
-    if [[ ${CIDER_SGID} =~ .*sg-* ]]; then
+    if [[ ${DEST_SRC} =~ sg-[[:alnum:]]+ ]]; then
+        # SG-ID
         SUBCMD_PRM1='UserIdGroupPairs'
         SUBCMD_PRM2='GroupId'
-    elif [[ ${CIDER_SGID} =~ .*[1-9]*\.[0-9]*\.[0-9]*\.[0-9]*[0-9] ]]; then
+    elif [[ ${DEST_SRC} =~ [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+ ]]; then
+        # IPv4 CIDER
         SUBCMD_PRM1='IpRanges'
         SUBCMD_PRM2='CidrIp'
+    elif [[ ${DEST_SRC} =~ [0-9a-fA-F:]+/[0-9]+ ]]; then
+        # IPv6 CIDER
+        SUBCMD_PRM1='Ipv6Ranges'
+        SUBCMD_PRM2='CidrIpv6'
     fi
     
     # Set subcommand parameter: Description
@@ -85,44 +103,61 @@ function func_create_cmd() {
     fi
     
     # '-1' for protocol means all traffic, no need to specify port
-    if [[ ${PROTOCOL} =~ .*-1 ]]; then
-        SUBCOMD_TMP="${SUBCMD} --group-id ${SECURITY_GROUP_ID} --ip-permissions IpProtocol=${PROTOCOL},${SUBCMD_PRM1}='[{${SUBCMD_PRM2}=${CIDER_SGID}"${SUBCMD_PRM3}"}]'"
+    if [[ ${PROTOCOL} =~ -1 ]]; then
+        SUBCOMD_TMP="${SUBCMD} --group-id ${SG_ID} --ip-permissions IpProtocol=${PROTOCOL},${SUBCMD_PRM1}='[{${SUBCMD_PRM2}=${DEST_SRC}"${SUBCMD_PRM3}"}]'"
     else
-        SUBCOMD_TMP="${SUBCMD} --group-id ${SECURITY_GROUP_ID} --ip-permissions IpProtocol=${PROTOCOL},FromPort=${FROM_PORT},ToPort=${TO_PORT},${SUBCMD_PRM1}='[{${SUBCMD_PRM2}=${CIDER_SGID}"${SUBCMD_PRM3}"}]'"
+        SUBCOMD_TMP="${SUBCMD} --group-id ${SG_ID} --ip-permissions IpProtocol=${PROTOCOL},FromPort=${FROM_PORT},ToPort=${TO_PORT},${SUBCMD_PRM1}='[{${SUBCMD_PRM2}=${DEST_SRC}"${SUBCMD_PRM3}"}]'"
     fi
     
     # Assembling commands
     CMD="${AWSCLI_CMD} ${SUBCOMD_TMP}"
+    
+    return 0
 }
 
 # Main
 # Read and process rules from list file
-while IFS=',' read -r SECURITY_GROUP_ID PROTOCOL FROM_PORT TO_PORT CIDER_SGID DESCRIPTION
+while IFS=',' read -r SG_ID PROTOCOL FROM_PORT TO_PORT DEST_SRC DESCRIPTION TEMP
 do
-    case "${ACTION}" in
-        "add" )
-          func_create_cmd "${SECURITY_GROUP_ID}" "${PROTOCOL}" "${FROM_PORT}" "${TO_PORT}" "${CIDER_SGID}" "${DESCRIPTION}"
-          echo -e "Add command: ${CMD}" 2>&1 | tee -a ${LOGFILE}
-          eval ${CMD} 2>&1 | tee -a ${LOGFILE}
-          ;;
-        "del" )
-          func_create_cmd "${SECURITY_GROUP_ID}" "${PROTOCOL}" "${FROM_PORT}" "${TO_PORT}" "${CIDER_SGID}"
-          echo -e "Delete command: ${CMD}" 2>&1 | tee -a ${LOGFILE}
-          eval ${CMD} 2>&1 | tee -a ${LOGFILE}
-          ;;
-        "addshow" )
-          func_create_cmd "${SECURITY_GROUP_ID}" "${PROTOCOL}" "${FROM_PORT}" "${TO_PORT}" "${CIDER_SGID}" "${DESCRIPTION}"
-          echo -e "${CMD}" 2>&1 | tee -a ${LOGFILE}
-          ;;
-        "delshow" )
-          func_create_cmd "${SECURITY_GROUP_ID}" "${PROTOCOL}" "${FROM_PORT}" "${TO_PORT}" "${CIDER_SGID}"
-          echo -e "${CMD}" 2>&1 | tee -a ${LOGFILE}
-          ;;
+    # Remove "(Double quotation) from field
+    SG_ID=$(echo "${SG_ID}" | sed 's/"//g')
+    PROTOCOL=$(echo "${PROTOCOL}" | sed 's/"//g')
+    FROM_PORT=$(echo "${FROM_PORT}" | sed 's/"//g')
+    TO_PORT=$(echo "${TO_PORT}" | sed 's/"//g')
+    DEST_SRC=$(echo "${DEST_SRC}" | sed 's/"//g')
+
+    # Check field sg-id
+    if [[ ! ${SG_ID} =~ sg-[[:alnum:]]+ ]]; then
+        echo "Skip: "${SG_ID}", "${PROTOCOL}", "${FROM_PORT}", "${TO_PORT}", "${DEST_SRC}""
+        continue
+    fi
+    
+    if [[ ${DESCRIPTION} =~ \# ]]; then
+        DESCRIPTION=''
+    fi
+
+    case "${EX_OPTIN}" in
+        "-y" )
+            if [[ ${ACTION} == "add" ]]; then
+                func_create_cmd "${SG_ID}" "${PROTOCOL}" "${FROM_PORT}" "${TO_PORT}" "${DEST_SRC}" "${DESCRIPTION}"
+                echo -e "Add command: ${CMD}" 2>&1 | tee -a ${LOGFILE}
+            elif [[ ${ACTION} == "del" ]]; then
+                func_create_cmd "${SG_ID}" "${PROTOCOL}" "${FROM_PORT}" "${TO_PORT}" "${DEST_SRC}"
+                echo -e "Delete command: ${CMD}" 2>&1 | tee -a ${LOGFILE}
+            fi
+            eval ${CMD} 2>&1 | tee ${LOGFILE}.tmp
+            # Remove prefix when running debug mode
+            grep -v '^++' ${LOGFILE}.tmp >> ${LOGFILE}
+            rm -f ${LOGFILE}.tmp
+            ;;
         * )
-          echo -e "Error: Invalid argument: ${ACTION}"
-          echo -e "Usage: ${USAGE}"
-          exit 20
-          ;;
+            if [[ ${ACTION} == "add" ]]; then
+                func_create_cmd "${SG_ID}" "${PROTOCOL}" "${FROM_PORT}" "${TO_PORT}" "${DEST_SRC}" "${DESCRIPTION}"
+            elif [[ ${ACTION} == "del" ]]; then
+                func_create_cmd "${SG_ID}" "${PROTOCOL}" "${FROM_PORT}" "${TO_PORT}" "${DEST_SRC}"
+            fi
+            echo ${CMD} 2>&1 | tee -a ${LOGFILE}
+            ;;
     esac
-done < <(awk -F',' '{ if($1~"^[^#]") print $0}' "$3" | tr -d '\r')
+done < <(awk -F',' '{ if($1~"^[^#]") print $0}' "${RULE_LIST}" | tr -d '\r')
 exit 0

--- a/sample-list
+++ b/sample-list
@@ -1,4 +1,4 @@
-#<group-id>,<protocol>,<from-port>,<to-port>,<CIDR|group-id>,<DESCRIPTION>
+#<group-id>,<protocol>,<from-port>,<to-port>,<CIDR|group-id>,<DESCRIPTION>,#memo
 #sg-nnnn,icmp,-1,-1,sg-nnnn,"ICMP"
 #sg-nnnn,-1,,,sg-nnnn,"all traffic"
 #sg-nnnn,udp,80,80,"0.0.0.0/0"


### PR DESCRIPTION
- 引数に実際にAWS CLI コマンドを叩くのオプションを追加
- それに伴い、第1引数のaddshow、delshowを削除
- while文の最後にダミーフィールドを入れつことで、フィールドの結合を回避
- while文にSG-IDが適切かどうかif文処理にcontinueを入れた
- DESCRIPTIONフィールドに#があれば、DESCRIPTIONを空にする。リストファイルのルールのメモとして記述できるようにした
- bashのdebug modeだとecvalでAWS CLIコマンド実行する際、ログファイルにデバックのプレフィックス(++)が追記されるので、回避を入れた